### PR TITLE
Update the Godot Git repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Godot-wrapper
 =============
 
-A BASH script that downloads and integrates the [Godot engine](http://www.godotengine.org/) for Ubuntu. It also enables version managing and installation of git master. The application icon belongs to the [Godot project](https://github.com/okamstudio/godot).
+A BASH script that downloads and integrates the [Godot engine](http://www.godotengine.org/) for Ubuntu. It also enables version managing and installation of git master. The application icon belongs to the [Godot project](https://github.com/godotengine/godot).
 
 There's a one-liner copy-and-paste here below to get Godot installed:
 

--- a/godot
+++ b/godot
@@ -32,7 +32,7 @@ cd "$appdir"
 
 applauncher="$appdir/godot.desktop"
 appscript="$appdir/$(basename "$0")"
-repo="https://github.com/okamstudio/godot.git"
+repo="https://github.com/godotengine/godot.git"
 json_releases=""
 
 if [ "$(uname -m)" = "x86_64" ]; then


### PR DESCRIPTION
While the old URL currently still redirects to the new one, it's a better idea to use the new URL directly :smiley: